### PR TITLE
Headers | link: rel=modulepreload support/capability #106

### DIFF
--- a/src/push.ts
+++ b/src/push.ts
@@ -20,7 +20,7 @@ import * as validUrl from 'valid-url';
  */
 export interface PushManifestData {
   [pattern: string]: {
-    [resource: string]: {type: string; crossorigin?: string; weight?: number;}
+    [resource: string]: {type: string; crossorigin?: string; rel?: string; weight?: number;}
   }
 }
 
@@ -34,7 +34,8 @@ export class PushManifest {
     Map<string,
         {
           type: string;
-          crossorigin: string|null
+          crossorigin: string|null;
+          rel: string|null
         }>
   ]>();
 
@@ -66,6 +67,10 @@ export class PushManifest {
         validatePath(resource);
         const type = manifest[pattern][resource].type || '';
         const crossorigin = manifest[pattern][resource].crossorigin || null;
+        const rel = manifest[pattern][resource].rel || 'preload';
+        if (!requestRelation.has(rel)) {
+          throw new Error(`invalid rel: ${rel}`);
+        }
         if (!requestDestinations.has(type)) {
           throw new Error(`invalid type: ${type}`);
         }
@@ -102,8 +107,8 @@ export class PushManifest {
       if (!resources || !pattern.test(normalizedPattern)) {
         continue;
       }
-      for (const [resource, {type, crossorigin}] of resources.entries()) {
-        let header = `<${resource}>; rel=preload`;
+      for (const [resource, {type, crossorigin, rel}] of resources.entries()) {
+        let header = `<${resource}>; rel=${rel}`;
         if (type) {
           header += `; as=${type}`;
         }
@@ -154,4 +159,10 @@ const requestDestinations = new Set([
   'video',
   'worker',
   'xslt'
+]);
+
+// From https://html.spec.whatwg.org/multipage/links.html#linkTypes
+const requestRelation = new Set([
+  'preload',
+  'modulepreload'
 ]);

--- a/src/test/push_test.ts
+++ b/src/test/push_test.ts
@@ -159,4 +159,21 @@ suite('PushManifest', function() {
       '</d.html>; rel=preload; as=document; crossorigin=use-credentials',
     ]);
   });
+
+  test('rel setting works', () => {
+    const manifest = new push.PushManifest({
+      '/foo': {
+        '/a.html': {type: 'document'},
+        '/b.html': {type: 'document', crossorigin: ''},
+        '/c.html': {type: 'document', crossorigin: 'anonymous', rel:'preload'},
+        '/d.html': {type: 'document', crossorigin: 'use-credentials', rel:'modulepreload'},
+      },
+    });
+    assert.deepEqual(manifest.linkHeaders('/foo'), [
+      '</a.html>; rel=preload; as=document',
+      '</b.html>; rel=preload; as=document',
+      '</c.html>; rel=preload; as=document; crossorigin=anonymous',
+      '</d.html>; rel=modulepreload; as=document; crossorigin=use-credentials',
+    ]);
+  });
 });


### PR DESCRIPTION
Pull request to solve this issue

https://github.com/Polymer/prpl-server/issues/106
----
So far, all link are set as `rel=preload`.
It could be useful to choose if we want `preload` or `modulepreload`.
So the browser wouldn't load twice a module file and avoid this kind of warning
![Screenshot 2021-06-18 at 15 47 59](https://user-images.githubusercontent.com/66091127/122571013-945ac280-d04c-11eb-9187-915c9673e6fd.png)


To do so, we could add an optional argument to push-manifest.json.
This could be implemented in https://github.com/Polymer/prpl-server/blob/master/src/push.ts 

Here is a possible implementation :
<img width="721" alt="Screenshot 2021-06-18 at 15 09 46" src="https://user-images.githubusercontent.com/66091127/122565880-3c6d8d00-d047-11eb-95b9-ef607e13491e.png">
<img width="398" alt="Screenshot 2021-06-18 at 15 10 03" src="https://user-images.githubusercontent.com/66091127/122565914-455e5e80-d047-11eb-9c63-acbf1d149ff3.png">
<img width="601" alt="Screenshot 2021-06-18 at 15 10 26" src="https://user-images.githubusercontent.com/66091127/122565964-527b4d80-d047-11eb-86d7-779b03651a1b.png">
<img width="572" alt="Screenshot 2021-06-18 at 15 13 28" src="https://user-images.githubusercontent.com/66091127/122566350-bf8ee300-d047-11eb-8d68-c36705221618.png">
<img width="499" alt="Screenshot 2021-06-18 at 15 10 43" src="https://user-images.githubusercontent.com/66091127/122566004-5c9d4c00-d047-11eb-80c9-6671159c13fc.png">

**references :** 
https://developers.google.com/web/updates/2017/12/modulepreload
https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload